### PR TITLE
Only run Husky in non-production environments

### DIFF
--- a/.husky/install.mjs
+++ b/.husky/install.mjs
@@ -1,0 +1,7 @@
+if (process.env.NODE_ENV === 'production' || process.env.CI === 'true')
+  process.exit(0);
+
+const husky = (await import('husky')).default;
+console.log(husky());
+
+export {};

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "postbuild": "node src/build/post/index.mjs",
     "format": "prettier --write --ignore-unknown .",
     "test": "prettier --check --ignore-unknown .",
-    "prepare": "husky"
+    "prepare": "node .husky/install.mjs"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## What should this PR do?

Only runs Husky in non-production environments, as it is a development-only dependency. When only production dependencies are installed, such as in App Platform, the `prepare` script that calls `husky` would fail.

## What issue does this relate to?

N/A

## What are the acceptance criteria?

Husky installs without issue when running `npm ci`. Husky does not install and does not error when running `npm ci --production`.