### PR TITLE
Add additional short URL redirects to page sections

### DIFF
--- a/.do/deploy.template.yaml
+++ b/.do/deploy.template.yaml
@@ -68,5 +68,97 @@ spec:
           path:
             prefix: /security.txt
         redirect:
+          authority: hacktoberfest.com
           redirect_code: 301
           uri: /.well-known/security.txt
+      - match:
+          path:
+            prefix: /values
+        redirect:
+          authority: hacktoberfest.com
+          redirect_code: 302
+          uri: /participation/#values
+      - match:
+          path:
+            prefix: /contributors
+        redirect:
+          authority: hacktoberfest.com
+          redirect_code: 302
+          uri: /participation/#contributors
+      - match:
+          path:
+            prefix: /resources
+        redirect:
+          authority: hacktoberfest.com
+          redirect_code: 302
+          uri: /participation/#beginner-resources
+      - match:
+          path:
+            prefix: /spam
+        redirect:
+          authority: hacktoberfest.com
+          redirect_code: 302
+          uri: /participation/#spam
+      - match:
+          path:
+            prefix: /maintainers
+        redirect:
+          authority: hacktoberfest.com
+          redirect_code: 302
+          uri: /participation/#maintainers
+      - match:
+          path:
+            prefix: /faq
+        redirect:
+          authority: hacktoberfest.com
+          redirect_code: 302
+          uri: /participation/#faq
+      - match:
+          path:
+            prefix: /organizers
+        redirect:
+          authority: hacktoberfest.com
+          redirect_code: 302
+          uri: /events/#organizers
+      - match:
+          path:
+            prefix: /brand
+        redirect:
+          authority: hacktoberfest.com
+          redirect_code: 302
+          uri: /events/#brand
+      - match:
+          path:
+            prefix: /lore
+        redirect:
+          authority: hacktoberfest.com
+          redirect_code: 302
+          uri: /about/#lore
+      - match:
+          path:
+            prefix: /love
+        redirect:
+          authority: hacktoberfest.com
+          redirect_code: 302
+          uri: /about/#love
+      - match:
+          path:
+            prefix: /sponsors
+        redirect:
+          authority: hacktoberfest.com
+          redirect_code: 302
+          uri: /about/#sponsors
+      - match:
+          path:
+            prefix: /rewards
+        redirect:
+          authority: hacktoberfest.com
+          redirect_code: 302
+          uri: /about/#rewards
+      - match:
+          path:
+            prefix: /council
+        redirect:
+          authority: hacktoberfest.com
+          redirect_code: 302
+          uri: /about/#council


### PR DESCRIPTION
## What should this PR do?

Adds a bunch of short URL redirects to sections of pages on the site, so you could link to hacktoberfest.com/spam (or even hacktoberfe.st/spam) and get to the spam section of the participation page.

## What issue does this relate to?

N/A

## What are the acceptance criteria?

All the short URLs make sense, and go to the correct anchors on the pages.