### PR TITLE
Update first issue link in participation.js

### DIFF
--- a/src/lib/participation.js
+++ b/src/lib/participation.js
@@ -104,7 +104,7 @@ export const resources = {
         '[GitHub] [Participating Hacktoberfest projects](https://github.com/topics/hacktoberfest)',
         '[GitLab] [Participating Hacktoberfest projects](https://go.gitlab.com/ubCLKL)',
         '[GitHub] [Explore projects with issues on up-for-grabs.net](https://up-for-grabs.net/)',
-        '[GitHub] [Explore projects with issues on firstissue.dev](https://firstissue.dev/)',
+        '[GitHub] [Explore projects with issues on goodfirstissue.dev](https://goodfirstissue.dev/)',
         '[GitHub] [Explore Hacktoberfest projects on hacktoberfest-projects.vercel.app](https://hacktoberfest-projects.vercel.app)',
       ],
     },


### PR DESCRIPTION
## What should this PR do?

Replaced stale link with up to date link

## What issue does this relate to?

Closes https://github.com/Hacktoberfest/hacktoberfest-2022/issues/62

## What are the acceptance criteria?

- Updated link goes to expected site
