### PR TITLE
Add Nohemi to Sammy easter egg

### DIFF
--- a/src/lib/sammy.js
+++ b/src/lib/sammy.js
@@ -37,7 +37,7 @@ export const sammy = `
   /*******   //*******    /********//******   //**   //******
   ///////     ///////     ////////  //////     //     //////
 
-@eye_of_doritto, @erhilse and @MattIPv4 were here.
+@nohemidesign, @eye_of_doritto, @erhilse and @MattIPv4 were here.
 We hope you enjoy the theme for Hacktoberfest this year!
 
 (Oh, btw, we're hiring: https://www.digitalocean.com/careers)


### PR DESCRIPTION
## What should this PR do?

Adds Nohemi to the Sammy easter egg, who did most of the design work for the site this year.

## What issue does this relate to?

N/A

## What are the acceptance criteria?

Nohemi is in the easter egg with the correct Twitter (X) handle.