### PR TITLE
Style auth errors properly w/ recommendation for email overlap

### DIFF
--- a/src/components/notification.js
+++ b/src/components/notification.js
@@ -41,7 +41,7 @@ const StyledNotification = styled.div`
     `}
 `;
 
-const Notification = ({ title, children, color }) => {
+const Notification = ({ title, children, color, className }) => {
   // Check if all the children are paragraphs
   const paragraphs =
     children &&
@@ -50,7 +50,11 @@ const Notification = ({ title, children, color }) => {
         children.every((child) => child.type === 'p')));
 
   return (
-    <StyledNotification $color={color} $paragraphs={paragraphs}>
+    <StyledNotification
+      $color={color}
+      $paragraphs={paragraphs}
+      className={className}
+    >
       <h2>{title}</h2>
       {children}
     </StyledNotification>

--- a/src/pages/auth.js
+++ b/src/pages/auth.js
@@ -50,10 +50,20 @@ const StyledCardRow = styled.div`
   }
 `;
 
+const errorMap = {
+  'InvalidCredentials: Account already exists with matching email address':
+    'An account already exists with the email address you are trying to use. If you have participated in a previous year, please use the same GitHub/Gitlab account as before to log in.',
+};
+
 const Auth = () => {
   const auth = useAuth();
   const router = useRouter();
   const theme = useTheme();
+
+  const error =
+    router.query.error_code && router.query.error_message
+      ? `${router.query.error_code}: ${router.query.error_message}`
+      : null;
 
   return (
     <>
@@ -79,13 +89,19 @@ const Auth = () => {
               </div>
             ) : (
               <>
-                {!!(router.query.error_code && router.query.error_message) && (
+                {error && (
                   <StyledNotification title="Error" color={theme.colors.error}>
                     <p>
-                      An error occurred while authenticating you. <br />
-                      <code>
-                        {router.query.error_code}: {router.query.error_message}
-                      </code>
+                      An error occurred while authenticating you.{' '}
+                      {errorMap[error] || (
+                        <>
+                          <br />
+                          <code>
+                            {router.query.error_code}:{' '}
+                            {router.query.error_message}
+                          </code>
+                        </>
+                      )}
                     </p>
                   </StyledNotification>
                 )}

--- a/src/pages/auth.js
+++ b/src/pages/auth.js
@@ -52,7 +52,7 @@ const StyledCardRow = styled.div`
 
 const errorMap = {
   'InvalidCredentials: Account already exists with matching email address':
-    'An account already exists with the email address you are trying to use. If you have participated in a previous year, please use the same GitHub/Gitlab account as before to log in.',
+    'An account already exists with the email address you are trying to use. If you have participated in a previous year, please use the same GitHub/GitLab account as before to log in.',
 };
 
 const Auth = () => {

--- a/src/pages/auth.js
+++ b/src/pages/auth.js
@@ -1,27 +1,31 @@
 import Head from 'next/head';
 import { useRouter } from 'next/router';
-import styled, { keyframes } from 'styled-components';
+import styled, { useTheme } from 'styled-components';
 
 import Loader from 'components/loader';
+import Container from 'components/Container';
+import Card from 'components/Card';
+import Section from 'components/Section';
+import Notification from 'components/notification';
+import Type from 'components/type';
 
 import useAuth from 'hooks/useAuth';
 
 import { oauth } from 'lib/api';
-import Container from 'components/Container';
-import Card from 'components/Card';
-import Section from 'components/Section';
+import createMetaTitle from 'lib/createMetaTitle';
 
 import {
   breakpoints as bp,
   determineMediaQuery as mQ,
 } from 'themes/breakpoints';
-
 import { body24 } from 'themes/typography';
 
 import logoGithub from 'assets/img/logo-github.svg';
 import logoGitlab from 'assets/img/logo-gitlab.svg';
-import Type from 'components/type';
-import createMetaTitle from 'lib/createMetaTitle';
+
+const StyledNotification = styled(Notification)`
+  margin: 0 0 40px;
+`;
 
 const StyledP = styled.p`
   display: inline-flex;
@@ -29,13 +33,13 @@ const StyledP = styled.p`
   ${body24}
 `;
 
-export const StyledAuth = styled.div`
+const StyledAuth = styled.div`
   background: ${({ theme }) => theme.colors.darkGreen};
   color: ${({ theme }) => theme.colors.typography};
   padding: 68px 0;
 `;
 
-export const StyledCardRow = styled.div`
+const StyledCardRow = styled.div`
   display: grid;
   grid-template-columns: minmax(0, 1fr);
   gap: 32px;
@@ -49,6 +53,7 @@ export const StyledCardRow = styled.div`
 const Auth = () => {
   const auth = useAuth();
   const router = useRouter();
+  const theme = useTheme();
 
   return (
     <>
@@ -75,13 +80,14 @@ const Auth = () => {
             ) : (
               <>
                 {!!(router.query.error_code && router.query.error_message) && (
-                  <p>
-                    <strong>ERROR: Authentication process failed.</strong>
-                    <br />
-                    <code>
-                      {router.query.error_code}: {router.query.error_message}
-                    </code>
-                  </p>
+                  <StyledNotification title="Error" color={theme.colors.error}>
+                    <p>
+                      An error occurred while authenticating you. <br />
+                      <code>
+                        {router.query.error_code}: {router.query.error_message}
+                      </code>
+                    </p>
+                  </StyledNotification>
                 )}
                 <StyledP width="25">
                   {'>>'} Boot dialogue: 


### PR DESCRIPTION
## What should this PR do?

Styles errors generated during the authentication flow as actual errors, and adds copy for the recommended remediation when encountering the email overlap error.

| Before | After |
|-|-|
| ![image](https://github.com/user-attachments/assets/474782d4-7fbd-4462-b9af-13b5390ee83d) | ![image](https://github.com/user-attachments/assets/a0ce5b42-6a28-4bf1-930f-4323db3388b8) |

## What issue does this relate to?

N/A

## What are the acceptance criteria?

Auth errors are rendered in an error notification box, with the auth error shown (or a recommendation in its place).
