### PR TITLE
Fix wrapping issues with typing animation

### DIFF
--- a/src/components/type.js
+++ b/src/components/type.js
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import styled from 'styled-components';
 
 const interval = 100;
-const idle = 1;
+const idle = 1000;
 
 const srOnly = {
   position: 'absolute',
@@ -13,14 +13,14 @@ const srOnly = {
   clip: 'rect(0, 0, 0, 0)',
 };
 
-const cursorStyle = {
-  color: 'inherit',
-  position: 'absolute',
-  background: 'inherit',
-  left: 'calc(100% - 3px)',
-  bottom: '0px',
-  'line-height': '1.28',
-};
+const StyledCursor = styled.span`
+  color: inherit;
+  position: absolute;
+  background: inherit;
+  left: calc(100% - 3px);
+  bottom: 0px;
+  line-height: 1.28;
+`;
 
 const StyledType = styled.span`
   background-image: ${({ $backgroundColor }) =>
@@ -120,7 +120,7 @@ const Type = ({
         $prefixColor={prefixColor}
       >
         {text.slice(0, progress)}
-        {cursor && <span style={cursorStyle}>_</span>}
+        {cursor && <StyledCursor>_</StyledCursor>}
       </StyledType>
       {!done && (
         <span aria-hidden="true" style={{ opacity: 0 }}>

--- a/src/components/type.js
+++ b/src/components/type.js
@@ -4,22 +4,21 @@ import styled from 'styled-components';
 const interval = 100;
 const idle = 1000;
 
-const srOnly = {
-  position: 'absolute',
-  width: '1px',
-  height: '1px',
-  margin: '-1px',
-  overflow: 'hidden',
-  clip: 'rect(0, 0, 0, 0)',
-};
+const ScreenReader = styled.span`
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+`;
 
 const StyledCursor = styled.span`
   color: inherit;
-  position: absolute;
   background: inherit;
-  left: calc(100% - 3px);
-  bottom: 0px;
-  line-height: 1.28;
+  margin-left: -1ch;
+  left: 1ch;
+  position: relative;
 `;
 
 const StyledType = styled.span`
@@ -129,7 +128,7 @@ const Type = ({
       )}
 
       {/* Screen readers should read the full text */}
-      <span style={srOnly}>{text}</span>
+      <ScreenReader>{text}</ScreenReader>
     </>
   );
 };

--- a/src/components/type.js
+++ b/src/components/type.js
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import styled from 'styled-components';
 
 const interval = 100;
-const idle = 1000;
+const idle = 1;
 
 const srOnly = {
   position: 'absolute',
@@ -11,6 +11,16 @@ const srOnly = {
   margin: '-1px',
   overflow: 'hidden',
   clip: 'rect(0, 0, 0, 0)',
+};
+
+const cursorStyle = {
+  color: 'inherit',
+  position: 'absolute',
+  background: 'inherit',
+  left: 'calc(100% -3px)',
+  bottom: '0px',
+  color: 'inherit',
+  'line-height': '1.27',
 };
 
 const StyledType = styled.span`
@@ -111,7 +121,7 @@ const Type = ({
         $prefixColor={prefixColor}
       >
         {text.slice(0, progress)}
-        {cursor && <span style={{ color: cursorColor }}>_</span>}
+        {cursor && <span style={cursorStyle}>_</span>}
       </StyledType>
       {!done && (
         <span aria-hidden="true" style={{ opacity: 0 }}>

--- a/src/components/type.js
+++ b/src/components/type.js
@@ -17,9 +17,8 @@ const cursorStyle = {
   color: 'inherit',
   position: 'absolute',
   background: 'inherit',
-  left: 'calc(100% -3px)',
+  left: 'calc(100% - 3px)',
   bottom: '0px',
-  color: 'inherit',
   'line-height': '1.27',
 };
 

--- a/src/components/type.js
+++ b/src/components/type.js
@@ -19,7 +19,7 @@ const cursorStyle = {
   background: 'inherit',
   left: 'calc(100% - 3px)',
   bottom: '0px',
-  'line-height': '1.27',
+  'line-height': '1.28',
 };
 
 const StyledType = styled.span`


### PR DESCRIPTION
## What should this PR do?

- Made the cursor disappear as soon as the typing is done by setting idle timer to 1 ms
- Made the cursor's position to absolute so that it doesn't interfere with the natural rendering of text

Minor issue: when looked carefully the line height of the cursor doesn't matches with that of the heading, but it is not really noticable until seen carefully

https://github.com/user-attachments/assets/7b210812-dc79-4432-ba77-9bc756f4b4df

## What issue does this relate to?

Closes #59

## What are the acceptance criteria?

Cursor no longer causes wrapping issues as reported in the issue.