### PR TITLE
Expand provider config with more specifics

### DIFF
--- a/src/components/PullRequest/index.js
+++ b/src/components/PullRequest/index.js
@@ -59,13 +59,15 @@ const PullRequest = ({ data, as }) => {
           <span>Title: </span> {data.title}
         </StyledPRTitle>
         <StyledPRMR>
-          <span>PR/MR: </span> {data.target}#{data.number}
+          <span>{providerMap[data.provider].prName}: </span> {data.target}
+          {providerMap[data.provider].referenceCharacter}
+          {data.number}
         </StyledPRMR>
         <ButtonMain
           href={data.url}
           target="_blank"
           rel="noreferrer"
-          children={`View on ${providerMap[data.provider]}`}
+          children={`View on ${providerMap[data.provider].name}`}
         />
       </StyledInfo>
     </StyledPullRequest>

--- a/src/components/profile/settings.js
+++ b/src/components/profile/settings.js
@@ -119,7 +119,7 @@ const Settings = ({ auth, isEdit = false }) => {
         const data = await err.response.json().catch(() => null);
         console.error(err, data);
         setError(
-          `An unknown error occurred while linking your ${providerMap[provider]} account. Please try again later.`,
+          `An unknown error occurred while linking your ${providerMap[provider].name} account. Please try again later.`,
         );
       });
       window.location.href = link.redirect;
@@ -135,7 +135,7 @@ const Settings = ({ auth, isEdit = false }) => {
 
       if (
         !confirm(
-          `Are you sure you want to unlink your ${providerMap[provider]} account from your Hacktoberfest registration?`,
+          `Are you sure you want to unlink your ${providerMap[provider].name} account from your Hacktoberfest registration?`,
         )
       )
         return;
@@ -145,7 +145,7 @@ const Settings = ({ auth, isEdit = false }) => {
           const data = await err.response.json().catch(() => null);
           console.error(err, data);
           setError(
-            `An unknown error occurred while unlinking your ${providerMap[provider]} account. Please try again later.`,
+            `An unknown error occurred while unlinking your ${providerMap[provider].name} account. Please try again later.`,
           );
         },
       );
@@ -393,7 +393,7 @@ const Settings = ({ auth, isEdit = false }) => {
                             type="button"
                             disabled={hasTrackingEnded}
                           >
-                            Unlink {providerMap[provider]} account:{' '}
+                            Unlink {providerMap[provider].name} account:{' '}
                             <span>@{oauth[provider].providerUsername}</span>
                           </StyledButtonLink>
                         ) : (
@@ -402,7 +402,7 @@ const Settings = ({ auth, isEdit = false }) => {
                             type="button"
                             disabled
                           >
-                            {providerMap[provider]} linked:{' '}
+                            {providerMap[provider].name} linked:{' '}
                             <span>@{oauth[provider].providerUsername}</span>
                           </StyledButtonLink>
                         )
@@ -412,7 +412,7 @@ const Settings = ({ auth, isEdit = false }) => {
                           type="button"
                           disabled={hasTrackingEnded}
                         >
-                          Link {providerMap[provider]} account
+                          Link {providerMap[provider].name} account
                         </StyledButtonLink>
                       )}
                     </Fragment>

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -70,10 +70,12 @@ export const launchDate = process.env.LAUNCH_DATE || '2024-09-01T12:00:00Z';
 /**
  * Used for:
  *   - Displaying nice names for PR/MR providers
+ *   - Showing the correct reference character on profile page
+ *   - Showing the correct name for PR/MR on the profile page
  *   - Provider selection on report page
  *   - Providers in profile link/unlinking
  */
 export const providerMap = Object.freeze({
-  github: 'GitHub',
-  gitlab: 'GitLab',
+  github: { name: 'GitHub', referenceCharacter: '#', prName: 'PR' },
+  gitlab: { name: 'GitLab', referenceCharacter: '!', prName: 'MR' },
 });

--- a/src/pages/report.js
+++ b/src/pages/report.js
@@ -73,7 +73,7 @@ const Report = () => {
               `Could not locate repository name '${repository}' with provider ${provider}`
           ) {
             setError(
-              `The repository name you provided could not be found on ${providerMap[provider]}.`,
+              `The repository name you provided could not be found on ${providerMap[provider].name}.`,
             );
             return;
           }
@@ -82,7 +82,7 @@ const Report = () => {
             data?.message === 'User is not authorized with provider'
           ) {
             setError(
-              `You need to link a ${providerMap[provider]} account to your registration to report repositories from that provider.`,
+              `You need to link a ${providerMap[provider].name} account to your registration to report repositories from that provider.`,
             );
             return;
           }
@@ -188,7 +188,9 @@ const Report = () => {
                   name="provider"
                   label="Provider"
                   value={provider}
-                  items={Object.entries(providerMap)}
+                  items={Object.entries(providerMap).map(
+                    ([provider, { name }]) => [provider, name],
+                  )}
                   onChange={(e) => setProvider(e.target.value)}
                   disabled={submitting}
                   required


### PR DESCRIPTION
## What should this PR do?

On GitLab, PRs are called MRs instead. Currently the page just says "PR/MR" instead of using just the correct term for each platform. Also, the reference characters for MRs are different. GitHub uses `#` while GitLab uses `!` (`#` is used for issues there)

This PR updates the profile page to show the correct terms and characters for each provider as visible in the screenshot below:

![PR/MR section on the profile page](https://github.com/user-attachments/assets/228c2400-71ca-4a1e-896f-2b054c0031d1)


## What issue does this relate to?

<!-- Use a GitHub keyword ('resolves #xx', 'fixes #xx', 'closes #xx') to automatically close the relevant issue. -->
Not sure if I need one as it is purely cosmetic, but I can open one if you want.

## What are the acceptance criteria?

I have tested the affected pages to a level that does not perform changes on other systems (for example, I did not actually report a repository to see if that still works, I only tested if the select renders properly and lets me select the different providers)

You might want to test that yourself.
<!-- Write a list of what reviewers should check before they approve this PR. -->
<!-- Before submitting the PR for review, make sure that all tests and linting pass. -->
