### PR TITLE
Show 'waiting' PRs as 'accepted (in review)'

### DIFF
--- a/src/components/PullRequest/PullRequest.styles.js
+++ b/src/components/PullRequest/PullRequest.styles.js
@@ -108,6 +108,7 @@ export const StyledEyebrowWrapper = styled.div`
 export const StyledEyebrow = styled.p`
   ${body16}
   border-radius: 8px;
+  font-variant-numeric: tabular-nums;
   padding: 6px 14px;
 `;
 

--- a/src/components/PullRequest/PullRequest.styles.js
+++ b/src/components/PullRequest/PullRequest.styles.js
@@ -124,13 +124,13 @@ export const StyledInfo = styled.div`
   }
 `;
 
-export const StyledPRTitle = styled.h3`
+export const StyledTitle = styled.h3`
   flex-basis: 0;
   flex-grow: 1;
   ${body20}
 `;
 
-export const StyledPRMR = styled.p`
+export const StyledDetails = styled.p`
   flex-basis: 0;
   flex-grow: 1;
   ${body20}

--- a/src/components/PullRequest/PullRequest.styles.js
+++ b/src/components/PullRequest/PullRequest.styles.js
@@ -4,6 +4,7 @@ import {
   breakpoints as bp,
   determineMediaQuery as mQ,
 } from 'themes/breakpoints';
+import ButtonMain from 'components/ButtonMain';
 
 const stateColors = {
   excluded: (theme) => theme.colors.black,
@@ -136,13 +137,12 @@ export const StyledDetails = styled.p`
   ${body20}
 `;
 
-export const StyledPullRequest = styled.div`
+export const StyledContainer = styled.div`
   display: flex;
   flex-direction: column;
   gap: 24px;
   position: relative;
   width: 100%;
-  transition: 0.2s ease;
 
   ${StyledEyebrow} {
     background: ${({ $state, theme }) => stateColors[$state](theme)};
@@ -150,5 +150,21 @@ export const StyledPullRequest = styled.div`
       $state === 'accepted' || $state === 'waiting'
         ? theme.colors.black
         : theme.colors.typography};
+  }
+`;
+
+export const StyledButton = styled(ButtonMain)`
+  white-space: nowrap;
+`;
+
+export const StyledPullRequest = styled.div`
+  align-items: flex-end;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+
+  ${mQ(bp.tablet)} {
+    gap: 64px;
+    flex-direction: row;
   }
 `;

--- a/src/components/PullRequest/index.js
+++ b/src/components/PullRequest/index.js
@@ -2,7 +2,6 @@ import { useState, useEffect, useCallback } from 'react';
 import { useRouter } from 'next/router';
 
 import { MarkdownInline } from 'components/markdown';
-import ButtonMain from 'components/ButtonMain';
 
 import useCountdown from 'hooks/useCountdown';
 
@@ -17,6 +16,8 @@ import {
   StyledPullRequest,
   StyledTitle,
   StyledDetails,
+  StyledContainer,
+  StyledButton,
 } from './PullRequest.styles';
 
 const PullRequest = ({ data, as }) => {
@@ -34,50 +35,52 @@ const PullRequest = ({ data, as }) => {
   }, [router.pathname]);
 
   return (
-    <StyledPullRequest as={as} $state={data.state.state}>
-      <StyledEyebrowWrapper>
-        <StyledEyebrow>
-          {pullRequestStates[data.state.state].title.replace(
-            '${timer}',
-            `${days}:${hours}:${minutes}:${seconds}`,
-          )}
-        </StyledEyebrow>
-        <StyledState onClick={toggle} aria-selected={open}>
-          ?
-          <div>
-            <MarkdownInline
-              string={pullRequestStates[
-                data.state.state
-              ].description.replaceAll(
-                '${pr}',
-                providerMap[data.provider].prName,
-              )}
-            />
-            <MarkdownInline
-              string={pullRequestValidation.replaceAll(
-                '${pr}',
-                providerMap[data.provider].prName,
-              )}
-            />
-          </div>
-        </StyledState>
-      </StyledEyebrowWrapper>
-      <StyledInfo>
-        <StyledTitle>
-          <span>Title: </span> {data.title}
-        </StyledTitle>
-        <StyledDetails>
-          <span>{providerMap[data.provider].prName}: </span> {data.target}
-          {providerMap[data.provider].referenceCharacter}
-          {data.number}
-        </StyledDetails>
-        <ButtonMain
-          href={data.url}
-          target="_blank"
-          rel="noreferrer"
-          children={`View on ${providerMap[data.provider].name}`}
-        />
-      </StyledInfo>
+    <StyledPullRequest as={as}>
+      <StyledContainer $state={data.state.state}>
+        <StyledEyebrowWrapper>
+          <StyledEyebrow>
+            {pullRequestStates[data.state.state].title.replace(
+              '${timer}',
+              `${days}:${hours}:${minutes}:${seconds}`,
+            )}
+          </StyledEyebrow>
+          <StyledState onClick={toggle} aria-selected={open}>
+            ?
+            <div>
+              <MarkdownInline
+                string={pullRequestStates[
+                  data.state.state
+                ].description.replaceAll(
+                  '${pr}',
+                  providerMap[data.provider].prName,
+                )}
+              />
+              <MarkdownInline
+                string={pullRequestValidation.replaceAll(
+                  '${pr}',
+                  providerMap[data.provider].prName,
+                )}
+              />
+            </div>
+          </StyledState>
+        </StyledEyebrowWrapper>
+        <StyledInfo>
+          <StyledTitle>
+            <span>Title: </span> {data.title}
+          </StyledTitle>
+          <StyledDetails>
+            <span>{providerMap[data.provider].prName}: </span> {data.target}
+            {providerMap[data.provider].referenceCharacter}
+            {data.number}
+          </StyledDetails>
+        </StyledInfo>
+      </StyledContainer>
+      <StyledButton
+        href={data.url}
+        target="_blank"
+        rel="noreferrer"
+        children={`View on ${providerMap[data.provider].name}`}
+      />
     </StyledPullRequest>
   );
 };

--- a/src/components/PullRequest/index.js
+++ b/src/components/PullRequest/index.js
@@ -46,9 +46,19 @@ const PullRequest = ({ data, as }) => {
           ?
           <div>
             <MarkdownInline
-              string={pullRequestStates[data.state.state].description}
+              string={pullRequestStates[
+                data.state.state
+              ].description.replaceAll(
+                '${pr}',
+                providerMap[data.provider].prName,
+              )}
             />
-            <MarkdownInline string={pullRequestValidation} />
+            <MarkdownInline
+              string={pullRequestValidation.replaceAll(
+                '${pr}',
+                providerMap[data.provider].prName,
+              )}
+            />
           </div>
         </StyledState>
       </StyledEyebrowWrapper>

--- a/src/components/PullRequest/index.js
+++ b/src/components/PullRequest/index.js
@@ -37,19 +37,17 @@ const PullRequest = ({ data, as }) => {
     <StyledPullRequest as={as} $state={data.state.state}>
       <StyledEyebrowWrapper>
         <StyledEyebrow>
-          {' '}
-          {data.state.state}
-          {data.state.state === 'waiting' && (
-            <>
-              {' '}
-              [{days}:{hours}:{minutes}:{seconds}]
-            </>
+          {pullRequestStates[data.state.state].title.replace(
+            '${timer}',
+            `${days}:${hours}:${minutes}:${seconds}`,
           )}
         </StyledEyebrow>
         <StyledState onClick={toggle} aria-selected={open}>
           ?
           <div>
-            <MarkdownInline string={pullRequestStates[data.state.state]} />
+            <MarkdownInline
+              string={pullRequestStates[data.state.state].description}
+            />
             <MarkdownInline string={pullRequestValidation} />
           </div>
         </StyledState>

--- a/src/components/PullRequest/index.js
+++ b/src/components/PullRequest/index.js
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback } from 'react';
 import { useRouter } from 'next/router';
 
 import { MarkdownInline } from 'components/markdown';
+import ButtonMain from 'components/ButtonMain';
 
 import useCountdown from 'hooks/useCountdown';
 
@@ -14,10 +15,9 @@ import {
   StyledEyebrow,
   StyledInfo,
   StyledPullRequest,
-  StyledPRTitle,
-  StyledPRMR,
+  StyledTitle,
+  StyledDetails,
 } from './PullRequest.styles';
-import ButtonMain from 'components/ButtonMain';
 
 const PullRequest = ({ data, as }) => {
   // Get countdown for waiting PRs
@@ -63,14 +63,14 @@ const PullRequest = ({ data, as }) => {
         </StyledState>
       </StyledEyebrowWrapper>
       <StyledInfo>
-        <StyledPRTitle>
+        <StyledTitle>
           <span>Title: </span> {data.title}
-        </StyledPRTitle>
-        <StyledPRMR>
+        </StyledTitle>
+        <StyledDetails>
           <span>{providerMap[data.provider].prName}: </span> {data.target}
           {providerMap[data.provider].referenceCharacter}
           {data.number}
-        </StyledPRMR>
+        </StyledDetails>
         <ButtonMain
           href={data.url}
           target="_blank"

--- a/src/components/profile/progress.js
+++ b/src/components/profile/progress.js
@@ -212,14 +212,16 @@ const Progress = ({ auth }) => {
             {Math.min(acceptedCount, 4).toLocaleString()}
             {acceptedCount > 4
               ? ` + ${(acceptedCount - 4).toLocaleString()}`
-              : ''}{' '}
-            <span>/</span> 4
-            {!!waitingCount && (
+              : ''}
+            {waitingCount > 0 ? (
               <>
                 {' '}
-                <span>[{waitingCount.toLocaleString()} in review]</span>
+                <span>+ {waitingCount.toLocaleString()} (in review)</span>
               </>
-            )}
+            ) : (
+              ''
+            )}{' '}
+            <span>/</span> 4
           </StyledCount>
         </StyledProgressSummary>
       </Section>

--- a/src/components/profile/progress.js
+++ b/src/components/profile/progress.js
@@ -23,20 +23,17 @@ const StyledProgressWrapper = styled.div`
 `;
 
 const StyledProgressSummary = styled.div`
+  ${body32}
   background: ${({ theme }) => theme.colors.darkGreen};
   border-radius: 16px;
+  color: ${({ theme }) => theme.colors.green};
+  font-weight: 500;
   padding: 24px 48px;
   text-align: center;
   max-width: 608px;
 
-  h2 {
-    ${body32}
-    font-weight: 500;
-    color: ${({ theme }) => theme.colors.green};
-
-    span {
-      color: ${({ theme }) => theme.colors.typography};
-    }
+  span {
+    color: ${({ theme }) => theme.colors.typography};
   }
 `;
 
@@ -146,19 +143,17 @@ const Progress = ({ auth }) => {
             size="lg"
           />
           <StyledProgressSummary>
-            <h2>
-              {Math.min(acceptedCount, 4).toLocaleString()}
-              {acceptedCount > 4
-                ? ` + ${(acceptedCount - 4).toLocaleString()}`
-                : ''}{' '}
-              <span>/</span> 4
-              {!!waitingCount && (
-                <>
-                  {' '}
-                  <span>[{waitingCount.toLocaleString()} waiting]</span>
-                </>
-              )}
-            </h2>
+            {Math.min(acceptedCount, 4).toLocaleString()}
+            {acceptedCount > 4
+              ? ` + ${(acceptedCount - 4).toLocaleString()}`
+              : ''}{' '}
+            <span>/</span> 4
+            {!!waitingCount && (
+              <>
+                {' '}
+                <span>[{waitingCount.toLocaleString()} in review]</span>
+              </>
+            )}
           </StyledProgressSummary>
         </StyledSectionSpacing>
       </Section>

--- a/src/components/profile/progress.js
+++ b/src/components/profile/progress.js
@@ -1,28 +1,70 @@
 import { Fragment, useEffect, useMemo, useRef, useState } from 'react';
-import styled, { useTheme } from 'styled-components';
+import styled, { keyframes, useTheme } from 'styled-components';
 import Link from 'next/link';
 
-import { body20, body24, body32 } from 'themes/typography';
-import { fetchGiftCodes, fetchPullRequests, triggerUserIngest } from 'lib/api';
-import { trackingStart } from 'lib/config';
+import { body16, body20, body24, body32 } from 'themes/typography';
+import {
+  fetchUserOAuth,
+  fetchGiftCodes,
+  fetchPullRequests,
+  triggerUserIngest,
+} from 'lib/api';
+import { providerMap, trackingStart } from 'lib/config';
+
+import { StyledSectionSpacing } from 'styles/sharedStyles';
 
 import Loader from 'components/loader';
 import Section from 'components/Section';
 import Notification from 'components/notification';
 import Divider from 'components/Divider';
 import PullRequest from 'components/PullRequest';
+import ContentMaster from 'components/ContentMaster';
 
 import EmailWarning from './email-warning';
 import Holopin from './rewards/holopin';
-import { StyledSectionSpacing } from 'styles/sharedStyles';
-import ContentMaster from 'components/ContentMaster';
 
 const StyledProgressWrapper = styled.div`
   display: flex;
   flex-direction: column;
 `;
 
-const StyledProgressSummary = styled.div`
+// Fade in after the 'progress' typing animation
+const trackingFade = keyframes`
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 0.75;
+  }
+`;
+
+const StyledTracking = styled.div`
+  align-items: baseline;
+  display: flex;
+  flex-flow: row wrap;
+
+  :not(p) {
+    flex-grow: 1;
+  }
+
+  p {
+    ${body16}
+    opacity: 0;
+    padding: 0 8px;
+
+    animation: ${trackingFade} ease 500ms;
+    animation-iteration-count: 1;
+    animation-fill-mode: forwards;
+    animation-delay: 1s;
+  }
+`;
+
+const StyledProgressSummary = styled(StyledSectionSpacing)`
+  max-width: 608px;
+`;
+
+const StyledCount = styled.p`
   ${body32}
   background: ${({ theme }) => theme.colors.darkGreen};
   border-radius: 16px;
@@ -30,7 +72,6 @@ const StyledProgressSummary = styled.div`
   font-weight: 500;
   padding: 24px 48px;
   text-align: center;
-  max-width: 608px;
 
   span {
     color: ${({ theme }) => theme.colors.typography};
@@ -63,6 +104,7 @@ const Progress = ({ auth }) => {
   // Track the data we need to render
   const [loaded, setLoaded] = useState(false);
   const loading = useRef(false);
+  const [oauth, setOauth] = useState([]);
   const [pullRequests, setPullRequests] = useState([]);
   const [giftCodes, setGiftCodes] = useState([]);
   const theme = useTheme();
@@ -74,20 +116,28 @@ const Progress = ({ auth }) => {
     loading.current = true;
 
     (async () => {
+      // Fetch the user's OAuth providers
+      const rawOauth = await fetchUserOAuth(auth.user.id, auth.token);
+      setOauth(
+        rawOauth.reduce(
+          (obj, item) => ({
+            ...obj,
+            [item.provider]: item,
+          }),
+          {},
+        ),
+      );
+
       // Fetch the user's pull requests
       const rawPullRequests = await fetchPullRequests(
         auth.user.id,
         auth.token,
         ['out-of-bounds'],
-      ).then((data) =>
-        data.filter(
-          (pr) => pr.state?.state && pr.state.state !== 'out-of-bounds',
-        ),
       );
       setPullRequests(
-        rawPullRequests.sort(
-          (a, b) => new Date(b.created_at) - new Date(a.created_at),
-        ),
+        rawPullRequests
+          .filter((pr) => pr.state?.state && pr.state.state !== 'out-of-bounds')
+          .sort((a, b) => new Date(b.created_at) - new Date(a.created_at)),
       );
 
       // Fetch the user's gift codes
@@ -121,8 +171,6 @@ const Progress = ({ auth }) => {
     [pullRequests],
   );
 
-  const hasError = useMemo;
-
   // Don't render anything until we have the data we need
   if (!loaded)
     return (
@@ -135,14 +183,32 @@ const Progress = ({ auth }) => {
   return (
     <StyledProgressWrapper>
       <Section small>
-        <StyledSectionSpacing $isSmall>
-          <ContentMaster
-            title="Progress"
-            titleAs="h2"
-            hasCaret={false}
-            size="lg"
-          />
-          <StyledProgressSummary>
+        <StyledProgressSummary $isSmall>
+          <StyledTracking>
+            <ContentMaster
+              title="Progress"
+              titleAs="h2"
+              hasCaret={false}
+              size="lg"
+            />
+
+            <p>
+              (Tracking{' '}
+              {[
+                ...new Set(
+                  Object.keys(oauth).map((p) => providerMap[p].prName),
+                ),
+              ].join('/')}
+              s for{' '}
+              {[
+                ...new Set(
+                  Object.values(oauth).map((o) => `@${o.providerUsername}`),
+                ),
+              ].join('/')}
+              )
+            </p>
+          </StyledTracking>
+          <StyledCount>
             {Math.min(acceptedCount, 4).toLocaleString()}
             {acceptedCount > 4
               ? ` + ${(acceptedCount - 4).toLocaleString()}`
@@ -154,8 +220,8 @@ const Progress = ({ auth }) => {
                 <span>[{waitingCount.toLocaleString()} in review]</span>
               </>
             )}
-          </StyledProgressSummary>
-        </StyledSectionSpacing>
+          </StyledCount>
+        </StyledProgressSummary>
       </Section>
 
       <Divider type="doubledashed" />

--- a/src/lib/participation.js
+++ b/src/lib/participation.js
@@ -580,7 +580,8 @@ export const faqs = {
       ],
     },
     {
-      title: 'Why is my pull/merge request in a maturing state on my profile?',
+      title:
+        'Why is my accepted pull/merge request showing as in review on my profile?',
       subtitle: 'Troubleshooting',
       collapsible: true,
       collapsed: true,

--- a/src/lib/profile.js
+++ b/src/lib/profile.js
@@ -2,42 +2,42 @@ export const pullRequestStates = {
   excluded: {
     title: 'Repository Excluded',
     description:
-      'Your PR/MR was submitted to a repository that has been excluded from Hacktoberfest as it does not follow the values of the event. It will not count towards your participation.',
+      'Your ${pr} was submitted to a repository that has been excluded from Hacktoberfest as it does not follow the values of the event. It will not count towards your participation.',
   },
   spam: {
     title: 'Marked as Spam',
     description:
-      'Your PR/MR has been identified as spam, either by automated logic, or by a maintainer adding a `spam` label to it. It will not count towards your participation. Two or more spam PR/MRs will result in permanent disqualification.',
+      'Your ${pr} has been identified as spam, either by automated logic, or by a maintainer adding a `spam` label to it. It will not count towards your participation. Two or more spam ${pr}s will result in permanent disqualification.',
   },
   'not-participating': {
     title: 'Repository Not Participating',
     description:
-      'Your PR/MR was submitted to a repository that is not participating in Hacktoberfest. Maintainers need to add the `hacktoberfest` topic to the repository, or add the `hacktoberfest-accepted` label to your PR/MR.',
+      'Your ${pr} was submitted to a repository that is not participating in Hacktoberfest. Maintainers need to add the `hacktoberfest` topic to the repository, or add the `hacktoberfest-accepted` label to your ${pr}.',
   },
   invalid: {
     title: 'Marked as Invalid',
     description:
-      'Your PR/MR has been labeled as `invalid`, and will not count towards your participation in Hacktoberfest.',
+      'Your ${pr} has been labeled as `invalid`, and will not count towards your participation in Hacktoberfest.',
   },
   'not-accepted': {
     title: 'Not Accepted',
     description:
-      'Your PR/MR has not yet been accepted by a maintainer of the repository. To be accepted, a maintainer either needs to merge your PR/MR, add the `hacktoberfest-accepted` label, or leave an overall approving review.',
+      'Your ${pr} has not yet been accepted by a maintainer of the repository. To be accepted, a maintainer either needs to merge your ${pr}, add the `hacktoberfest-accepted` label, or leave an overall approving review.',
   },
   waiting: {
     title: 'Accepted (In Review: ${timer})',
     description:
-      "Awesome! Your PR/MR has been accepted by a maintainer and is now in a seven-day review period. No action is needed, we'll take a look at your PR/MR and assuming it is still accepted after seven days it will count towards your participation in Hacktoberfest!",
+      "Awesome! Your ${pr} has been accepted by a maintainer and is now in a seven-day review period. No action is needed, we'll take a look at your ${pr} and assuming it is still accepted after seven days it will count towards your participation in Hacktoberfest!",
   },
   accepted: {
     title: 'Accepted',
     description:
-      'Congratulations! Your PR/MR has been accepted for Hacktoberfest, and now counts towards your participation. :party:',
+      'Congratulations! Your ${pr} has been accepted for Hacktoberfest, and now counts towards your participation. :party:',
   },
 };
 
 export const pullRequestValidation =
-  'For more information about how exactly we validate PR/MRs for contributors, check the [details on our participation page](/participation#pr-mr-details).';
+  'For more information about how exactly we validate ${pr}s for contributors, check the [details on our participation page](/participation#pr-mr-details).';
 
 export const employmentRoles = [
   'Back-end Developer',

--- a/src/lib/profile.js
+++ b/src/lib/profile.js
@@ -1,17 +1,39 @@
 export const pullRequestStates = {
-  excluded:
-    'Your PR/MR was submitted to a repository that has been excluded from Hacktoberfest as it does not follow the values of the event. It will not count towards your participation.',
-  spam: 'Your PR/MR has been identified as spam, either by automated logic, or by a maintainer adding a `spam` label to it. It will not count towards your participation. Two or more spam PR/MRs will result in permanent disqualification.',
-  'not-participating':
-    'Your PR/MR was submitted to a repository that is not participating in Hacktoberfest. Maintainers need to add the `hacktoberfest` topic to the repository, or add the `hacktoberfest-accepted` label to your PR/MR.',
-  invalid:
-    'Your PR/MR has been labeled as `invalid`, and will not count towards your participation in Hacktoberfest.',
-  'not-accepted':
-    'Your PR/MR has not yet been accepted by a maintainer of the repository. To be accepted, a maintainer either needs to merge your PR/MR, add the `hacktoberfest-accepted` label, or leave an overall approving review.',
-  waiting:
-    'Awesome! Your PR/MR has been accepted by a maintainer and is now in a seven-day review period. No action is needed, and assuming your PR/MR is still accepted after seven days it will count towards your participation in Hacktoberfest!',
-  accepted:
-    'Congratulations! Your PR/MR has been accepted for Hacktoberfest, and now counts towards your participation. :party:',
+  excluded: {
+    title: 'Repository Excluded',
+    description:
+      'Your PR/MR was submitted to a repository that has been excluded from Hacktoberfest as it does not follow the values of the event. It will not count towards your participation.',
+  },
+  spam: {
+    title: 'Marked as Spam',
+    description:
+      'Your PR/MR has been identified as spam, either by automated logic, or by a maintainer adding a `spam` label to it. It will not count towards your participation. Two or more spam PR/MRs will result in permanent disqualification.',
+  },
+  'not-participating': {
+    title: 'Repository Not Participating',
+    description:
+      'Your PR/MR was submitted to a repository that is not participating in Hacktoberfest. Maintainers need to add the `hacktoberfest` topic to the repository, or add the `hacktoberfest-accepted` label to your PR/MR.',
+  },
+  invalid: {
+    title: 'Marked as Invalid',
+    description:
+      'Your PR/MR has been labeled as `invalid`, and will not count towards your participation in Hacktoberfest.',
+  },
+  'not-accepted': {
+    title: 'Not Accepted',
+    description:
+      'Your PR/MR has not yet been accepted by a maintainer of the repository. To be accepted, a maintainer either needs to merge your PR/MR, add the `hacktoberfest-accepted` label, or leave an overall approving review.',
+  },
+  waiting: {
+    title: 'Accepted (In Review: ${timer})',
+    description:
+      "Awesome! Your PR/MR has been accepted by a maintainer and is now in a seven-day review period. No action is needed, we'll take a look at your PR/MR and assuming it is still accepted after seven days it will count towards your participation in Hacktoberfest!",
+  },
+  accepted: {
+    title: 'Accepted',
+    description:
+      'Congratulations! Your PR/MR has been accepted for Hacktoberfest, and now counts towards your participation. :party:',
+  },
 };
 
 export const pullRequestValidation =

--- a/src/pages/auth.js
+++ b/src/pages/auth.js
@@ -28,7 +28,6 @@ const StyledNotification = styled(Notification)`
 `;
 
 const StyledP = styled.p`
-  display: inline-flex;
   margin: 0 0 40px;
   ${body24}
 `;
@@ -84,9 +83,7 @@ const Auth = () => {
         <Section>
           <Container>
             {auth.loading ? (
-              <div>
-                <Loader message=">> Authorization in progress..." />
-              </div>
+              <Loader message=">> Authorization in progress..." />
             ) : (
               <>
                 {error && (
@@ -105,8 +102,8 @@ const Auth = () => {
                     </p>
                   </StyledNotification>
                 )}
-                <StyledP width="25">
-                  {'>>'} Boot dialogue: 
+                <StyledP>
+                  {'>>'} Boot dialogue:{' '}
                   <Type text="Initiating Pilot protocol" />
                 </StyledP>
                 <StyledCardRow>

--- a/src/pages/logout.js
+++ b/src/pages/logout.js
@@ -1,12 +1,19 @@
 import { useEffect, useState } from 'react';
 import Head from 'next/head';
+import styled from 'styled-components';
 
-import Divider from 'components/Divider';
 import Section from 'components/Section';
+import Container from 'components/Container';
 import Loader from 'components/loader';
 
 import useAuth from 'hooks/useAuth';
 import createMetaTitle from 'lib/createMetaTitle';
+
+const StyledLogout = styled.div`
+  background: ${({ theme }) => theme.colors.darkGreen};
+  color: ${({ theme }) => theme.colors.typography};
+  padding: 68px 0;
+`;
 
 const Logout = () => {
   const [redirect, setRedirect] = useState(false);
@@ -35,10 +42,13 @@ const Logout = () => {
         />
       </Head>
 
-      <Section type="sub_content">
-        <Divider />
-        <Loader message=">> Loading /usr/lib/logout..." />
-      </Section>
+      <StyledLogout>
+        <Section>
+          <Container>
+            <Loader message=">> Loading /usr/lib/logout..." />
+          </Container>
+        </Section>
+      </StyledLogout>
     </>
   );
 };


### PR DESCRIPTION
## What should this PR do?

To reduce the confusion around the seven-day waiting period for PR/MRs, and the `waiting` state that they are in during that time, reword the waiting state to be `accepted (in review)`.

This also includes a couple of fixes for styling on the auth + logout pages.

## What issue does this relate to?

N/A

## What are the acceptance criteria?

All references to PR/MRs waiting are reworded to be that the PR/MR is in review by the Hacktoberfest team.