### PR TITLE
Improve language for explaining bad/excluded repositories

### DIFF
--- a/src/lib/participation.js
+++ b/src/lib/participation.js
@@ -252,7 +252,7 @@ export const spam = {
       items: [
         {
           content:
-            'PR/MRs should be useful to maintainers. Repos that encourage simplistic PR/MRs (like adding a name or profile to a list or arbitrarily curating content) will be excluded from Hacktoberfest. Remember: quantity is fun, quality is key.\n\n' +
+            'PR/MRs should be useful to maintainers and be meaningful contributions to open-source software. Repositories that are created specifically for Hacktoberfest that do not benefit the wider open-source community, or repositories that encourage overly simplistic and inconsequential contributions such as adding a name or profile to a list or adding random content to a repo such as algorithms, will be excluded from Hacktoberfest. Remember: quantity is fun, quality is key.\n\n' +
             'Found a repository that you think doesn’t follow our values? [Report it to us and we’ll take a look](/report).',
         },
       ],


### PR DESCRIPTION
## What should this PR do?

Updates the copy used in the "Bad repositories will be excluded." explainer to help with folks understanding the types of repositories that we don't want to see as part of Hacktoberfest.

## What issue does this relate to?

N/A

## What are the acceptance criteria?

Language better explains what we consider a bad repository, and encourages folks to focus on legitimate repositories with legitimate contributions.