### PR TITLE
Improve language for email overlap error

### DIFF
--- a/src/pages/auth.js
+++ b/src/pages/auth.js
@@ -50,8 +50,19 @@ const StyledCardRow = styled.div`
 `;
 
 const errorMap = {
-  'InvalidCredentials: Account already exists with matching email address':
-    'An account already exists with the email address you are trying to use. If you have participated in a previous year, please use the same GitHub/GitLab account as before to log in.',
+  'InvalidCredentials: Account already exists with matching email address': (
+    <>
+      A Hacktoberfest account already exists with the email address you are
+      trying to use.
+      <br />
+      <br />
+      If you have participated in a previous year of Hacktoberfest, please make
+      sure to use the same GitHub/GitLab account as before to log in. If you're
+      looking to link accounts from both GitHub and GitLab, sign in with the
+      account that you've used previously for Hacktoberfest and then link the
+      other account under the edit profile view.
+    </>
+  ),
 };
 
 const Auth = () => {


### PR DESCRIPTION
## What should this PR do?

Updates the wording show in the error message when an overlapping email address is encountered, to account for both the wrong account being used but also when people might be attempting to link GitHub + GitLab (incorrectly).

## What issue does this relate to?

N/A

## What are the acceptance criteria?

Updated language reads correctly and accounts for both edge-cases that are likely to trigger this error.

Can be seen at `/auth/?error_code=InvalidCredentials&error_message=Account already exists with matching email address`.
