### PR TITLE
ISSUE-146 | Broken link on Home button redirecting to /register (404)

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -649,7 +649,7 @@ const Home = () => {
 
               {hasRegistrationStarted ? (
                 <StyledRegisterButtonContainer>
-                  <ButtonMain href="/register" passHref variant="primary">
+                  <ButtonMain href="/auth" passHref variant="primary">
                     REGISTER FOR HACKTOBERFEST
                   </ButtonMain>
                 </StyledRegisterButtonContainer>


### PR DESCRIPTION
## What should this PR do?

* Update the **Register for Hacktoberfest** button link from `/register` to `/auth`.

## What issue does this relate to?

This PR addresses the broken link issue: #146.

## What are the acceptance criteria?

* The maintainer should verify that the button is working correctly and redirects to the appropriate URL (`/auth`).


