### PR TITLE
fix: Loader styling inconsistency on profile page

### DIFF
--- a/src/pages/profile.js
+++ b/src/pages/profile.js
@@ -107,20 +107,18 @@ const Profile = () => {
         />
       </Head>
 
-      {auth.loading || !loaded ? (
-        <Section
-          bgColor={theme.colors.darkGreen}
-          color={theme.colors.typography}
-        >
-          <Container>
-            <Section>
+      <Layout>
+        {auth.loading || !loaded ? (
+          <Section
+            bgColor={theme.colors.darkGreen}
+            color={theme.colors.typography}
+          >
+            <Container>
               <Loader message=">> Loading /usr/lib/profile..." />
-            </Section>
-          </Container>
-        </Section>
-      ) : (
-        <>
-          <Layout>
+            </Container>
+          </Section>
+        ) : (
+          <>
             <Header
               avatar={avatar}
               name={auth.user.name}
@@ -168,11 +166,10 @@ const Profile = () => {
                 />
               </StyledButtonGroup>
             </Header>
-          </Layout>
-
-          {edit ? <Settings auth={auth} isEdit /> : <Progress auth={auth} />}
-        </>
-      )}
+            {edit ? <Settings auth={auth} isEdit /> : <Progress auth={auth} />}
+          </>
+        )}
+      </Layout>
     </>
   );
 };


### PR DESCRIPTION
## What should this PR do?
This PR fixes a styling inconsistency for the loader state on the profile page.
Register page loader:
<img width="1505" height="709" alt="Screenshot 2025-10-03 at 9 36 11 PM" src="https://github.com/user-attachments/assets/10dd6064-cb5b-4aa0-8057-fdb6c2d3ce55" />
Current profile page loader:
<img width="1635" height="782" alt="Screenshot 2025-10-03 at 9 36 38 PM" src="https://github.com/user-attachments/assets/264aefc9-7297-41a9-87d5-5e77a95cd526" />
Fixed profile page loader:
<img width="1539" height="541" alt="Screenshot 2025-10-03 at 9 38 25 PM" src="https://github.com/user-attachments/assets/4c25831b-a65c-4932-b282-9d762af24d09" />