### PR TITLE
fix: Remove invalid default error for report repo input field

### DIFF
--- a/src/pages/report.js
+++ b/src/pages/report.js
@@ -248,7 +248,6 @@ const Report = () => {
                         value={repository}
                         onChange={(e) => setRepository(e.target.value)}
                         disabled={submitting}
-                        error={'aaa'}
                         required
                       />
 


### PR DESCRIPTION
On the [report page](https://hacktoberfest.com/report/), the repository input field currently always shows an incorrect error titled `aaa`. This PR fixes that by removing the superfluous property.