### PR TITLE
fix: update fast-uri to 3.1.5 via lockfile (CVE-2026-13676, CVE-2026-18446)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1939,9 +1939,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.6.tgz",
-      "integrity": "sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-4.1.2.tgz",
+      "integrity": "sha512-TyGmBcbDTZXcb2cj5MV89DrF42DKvb3y5DDUNh95iO+IMeAzMkVSxK1PZRrRIpc9yg8U2GhGdbofNa0LS/a4Bw==",
       "funding": [
         {
           "type": "github",
@@ -4212,7 +4212,7 @@
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "requires": {
         "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
+        "fast-uri": "4.1.2",
         "json-schema-traverse": "^1.0.0",
         "require-from-string": "^2.0.2"
       }
@@ -4792,9 +4792,9 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "fast-uri": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.6.tgz",
-      "integrity": "sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw=="
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-4.1.2.tgz",
+      "integrity": "sha512-TyGmBcbDTZXcb2cj5MV89DrF42DKvb3y5DDUNh95iO+IMeAzMkVSxK1PZRrRIpc9yg8U2GhGdbofNa0LS/a4Bw=="
     },
     "fill-range": {
       "version": "7.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1071,6 +1071,22 @@
         "ajv": "^8.8.2"
       }
     },
+    "node_modules/ajv/node_modules/fast-uri": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/ansi-align": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
@@ -1937,22 +1953,6 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "license": "MIT"
-    },
-    "node_modules/fast-uri": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-4.1.2.tgz",
-      "integrity": "sha512-TyGmBcbDTZXcb2cj5MV89DrF42DKvb3y5DDUNh95iO+IMeAzMkVSxK1PZRrRIpc9yg8U2GhGdbofNa0LS/a4Bw==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fastify"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fastify"
-        }
-      ],
-      "license": "BSD-3-Clause"
     },
     "node_modules/fill-range": {
       "version": "7.1.1",
@@ -4212,9 +4212,16 @@
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "requires": {
         "fast-deep-equal": "^3.1.3",
-        "fast-uri": "4.1.2",
+        "fast-uri": "^3.0.1",
         "json-schema-traverse": "^1.0.0",
         "require-from-string": "^2.0.2"
+      },
+      "dependencies": {
+        "fast-uri": {
+          "version": "3.1.5",
+          "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+          "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw=="
+        }
       }
     },
     "ajv-formats": {
@@ -4790,11 +4797,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
-    },
-    "fast-uri": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-4.1.2.tgz",
-      "integrity": "sha512-TyGmBcbDTZXcb2cj5MV89DrF42DKvb3y5DDUNh95iO+IMeAzMkVSxK1PZRrRIpc9yg8U2GhGdbofNa0LS/a4Bw=="
     },
     "fill-range": {
       "version": "7.1.1",

--- a/package.json
+++ b/package.json
@@ -52,8 +52,5 @@
     "lint-staged": "^16.0.0",
     "prettier": "^3.5.3",
     "webpack": "^5.99.8"
-  },
-  "overrides": {
-    "fast-uri": "4.1.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -52,5 +52,8 @@
     "lint-staged": "^16.0.0",
     "prettier": "^3.5.3",
     "webpack": "^5.99.8"
+  },
+  "overrides": {
+    "fast-uri": "4.1.2"
   }
 }


### PR DESCRIPTION
## Summary

Updates `fast-uri` from 3.0.6 to 3.1.5 by regenerating the lockfile — no npm `overrides` block.

## Dependency path

```
serve@14.2.6
└── ajv@8.18.0 (declares "fast-uri": "^3.0.1")
    └── fast-uri@3.1.5  ← was 3.0.6
```

`ajv@8.x` has always declared `"fast-uri": "^3.0.1"`. `fast-uri@3.1.5` is the latest patched 3.x release and satisfies that range naturally, so the fix requires only a lockfile update — the `overrides` block from the previous commit has been removed.

## Vulnerabilities addressed

| CVE | Severity | Description |
|-----|----------|-------------|
| CVE-2026-13676 | HIGH | Security policy bypass via improper Unicode hostname canonicalization |
| CVE-2026-18446 (GHSA-7p8r-x3mc-p8w7) | HIGH | Additional fast-uri security issue patched in 3.1.5 / 4.1.2 / 2.4.4 |

## Verification

```
$ npm ls fast-uri
hacktoberfest-2022@0.1.0
└─┬ serve@14.2.6
  └─┬ ajv@8.18.0
    └── fast-uri@3.1.5
```

No `(overridden)` annotation — resolved naturally within ajv's declared range.

```
$ npm run test:unit
ℹ tests 193
ℹ pass  193
ℹ fail  0
```

## Changes

- `package.json` — removed `overrides` block
- `package-lock.json` — `fast-uri` now resolves to `3.1.5`